### PR TITLE
Remove 'Settings' and 'Time' panels from profiler toolbar

### DIFF
--- a/code/BurgersUnlimited/settings.py
+++ b/code/BurgersUnlimited/settings.py
@@ -174,10 +174,7 @@ DEBUG_TOOLBAR_CONFIG = {
     'SHOW_TOOLBAR_CALLBACK': lambda request: True,
     'SHOW_COLLAPSED': True,
 }
-DEBUG_TOOLBAR_PANELS = ['requests_panel.panel.RequestsDebugPanel',
-                        'debug_toolbar.panels.timer.TimerPanel',
-                        'debug_toolbar.panels.settings.SettingsPanel',
-                        ]
+DEBUG_TOOLBAR_PANELS = ['requests_panel.panel.RequestsDebugPanel']
 
 #DO NOT COMMIT THESE VALUES
 NEP_USERNAME = ''


### PR DESCRIPTION
This PR removes all toolbar panels in the profiler except for the "HTTP Requests" panel.

![image](https://user-images.githubusercontent.com/68287936/99097957-51aca580-25a6-11eb-8048-72bb66ce307e.png)
