### PR TITLE
Bug fix for about/documentation url mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ You will need to have the following:
 Ensure that you have access to your Shared Key, Secret Key, NEP Application Key and NEP Organzation. Inside of the settings file, ( found in /ncr-burgers-demo/code/BugersUnlimited) fill in those values with your credientials. Once you have filled in those values you will need to create your sites and catalog.
  
 1. Creating your Sites
-   * As part of your initial configuration, you will need to set up at least two sites; for instructions as to how to create a site, see the [site documentation](https://developer.ncr.com/portals/dev-portal/api-explorer/details/15/documentation?version=1.99&path=post_sites_import), or the section about sites on the [documentation page](https://burgersdemo.ncrcloud.com/burger/documentation#Sites_Quick_Start) within the application.
+   * As part of your initial configuration, you will need to set up at least two sites; for instructions as to how to create a site, see the [site documentation](https://developer.ncr.com/portals/dev-portal/api-explorer/details/15/documentation?version=1.99&path=post_sites_import), or the section about sites on the [documentation page](https://burgersdemo.ncrcloud.com/burger/about#Sites_Quick_Start) within the application.
 2. Creating your Catalog 
-   * As part of your initial configuration, you will need to set up your catalog, which will serve as your menu; for instructions as to how to create a catalog, see the [catalog documentation](https://developer.ncr.com/portals/dev-portal/api-explorer/details/8/documentation?version=2.99), or the section about catalogs on the [documentation page](https://burgersdemo.ncrcloud.com/burger/documentation#Tutorial_Catalog) within the application.
+   * As part of your initial configuration, you will need to set up your catalog, which will serve as your menu; for instructions as to how to create a catalog, see the [catalog documentation](https://developer.ncr.com/portals/dev-portal/api-explorer/details/8/documentation?version=2.99), or the section about catalogs on the [documentation page](https://burgersdemo.ncrcloud.com/burger/about#Tutorial_Catalog) within the application.
    
 Once you have completed the installation and configuration of the developer enviroment, you are ready to use the sample app.
 
@@ -68,7 +68,7 @@ The sample app should open up to the main page. The user can input an address in
 
 > If you do not set up your sites and catalog, the sample app will not function correctly.
 
-If you are using the sample app to learn more about the BSP HMAC algorithm, see the [HMAC](https://burgersdemo.ncrcloud.com/burger/documentation#Authentication_HMAC) section of the documentation within the application and check out the [HMACAuth](code/HMACAuth.py) file in the /ncr-burger-demo/code folder.
+If you are using the sample app to learn more about the BSP HMAC algorithm, see the [HMAC](https://burgersdemo.ncrcloud.com/burger/about#Authentication_HMAC) section of the documentation within the application and check out the [HMACAuth](code/HMACAuth.py) file in the /ncr-burger-demo/code folder.
 
 ## Troubleshooting
 If the **Profiler** tab is missing in the application, check the browser inspector for a console error about, "*Failure to load module script: The server responded with a non JavaScript MIME type..."* This issue may be caused by improper content mapping with Django's ```runserver``` command. Please refer to [these docs](https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#troubleshooting) for more information on troubleshooting this issue.

--- a/code/templates/highlandsMenu.html
+++ b/code/templates/highlandsMenu.html
@@ -74,7 +74,7 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ml-auto smooth-scroll d-lg-flex align-items-center mt-4" style="margin-bottom:0px; padding-bottom;0px">
            <li class="nav-item  ">
-               <a class="nav-link" href="{% url 'documentation' %}">Documentation</a>
+               <a class="nav-link" href="{% url 'about' %}">About</a>
            </li>
            {% if user.is_authenticated %}
                 <li class="nav-item h-100">

--- a/code/templates/index.html
+++ b/code/templates/index.html
@@ -48,7 +48,7 @@
                                                 <option value="5">5</option>
                                                 <option value="10">10</option>
                                                 <option value="15">15</option>
-                                                <option value="20">20</option>
+                                                <option value="20" selected>20</option>
                                             </select>
                                         </div>
                                 </div>

--- a/code/templates/midtownMenu.html
+++ b/code/templates/midtownMenu.html
@@ -74,7 +74,7 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ml-auto smooth-scroll d-lg-flex align-items-center mt-4" style="margin-bottom:0px; padding-bottom;0px">
            <li class="nav-item  ">
-               <a class="nav-link" href="{% url 'documentation' %}">Documentation</a>
+               <a class="nav-link" href="{% url 'about' %}">About</a>
            </li>
            {% if user.is_authenticated %}
                 <li class="nav-item h-100">

--- a/code/templates/southlandMenu.html
+++ b/code/templates/southlandMenu.html
@@ -85,7 +85,7 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ml-auto smooth-scroll d-lg-flex align-items-center mt-4" style="margin-bottom:0px; padding-bottom;0px">
            <li class="nav-item  ">
-               <a class="nav-link" href="{% url 'documentation' %}">Documentation</a>
+               <a class="nav-link" href="{% url 'about' %}">About</a>
            </li>
            {% if user.is_authenticated %}
                 <li class="nav-item h-100">


### PR DESCRIPTION
## Description
This pull requests fixes a bug where the navbar for some of the pages were not fully migrated from "Documentation" to "About". This changes all references of documentation to about.

This also adds the selected of 20 miles on the homepage radius (so we can close #1)

## Testing

1. Run the site locally
2. Visit each page and confirm no more 500 errors. 
3. Go to the readme and confirm the documentation links now point to `/about`

@tm185221 @cb185224 Let me know if you would like any changes.