### PR TITLE
Fixing issue with census API

### DIFF
--- a/code/auxMethods.py
+++ b/code/auxMethods.py
@@ -3,20 +3,21 @@ import requests
 import json
 from HMACAuth import HMACAuth
 
+
 def geoCodeAddress(address):
 
     try:
-        url='https://geocoding.geo.census.gov/geocoder/locations/onelineaddress'
+        url = 'https://geocoding.geo.census.gov/geocoder/locations/onelineaddress'
 
-        payload = {'address': address , 'benchmark' : '9', 'format' : 'json'}
+        payload = {'address': address,
+                   'benchmark': 'Public_AR_Current', 'format': 'json'}
 
-
-        r = requests.get(url,params=payload)
+        r = requests.get(url, params=payload)
         temp = r.json()
 
         rjson = json.dumps(temp)
         rjson = json.loads(rjson)
-        result =rjson['result']['addressMatches'][0]['coordinates']
+        result = rjson['result']['addressMatches'][0]['coordinates']
     except IndexError:
         print("Address could not be found")
     else:
@@ -28,25 +29,23 @@ def findResturantsInRange(coordinates, radius):
     # The radius in this function is in meters, so unit that user enters needs to be converted to from miles to meters
     meters = 1609
     y = coordinates['y']
-    x = coordinates ['x']
+    x = coordinates['x']
     circle = radius * meters
 
-    url = 'https://gateway-staging.ncrcloud.com/site/sites/find-nearby/%s,%s' %(coordinates['y'],coordinates['x'])
+    url = 'https://gateway-staging.ncrcloud.com/site/sites/find-nearby/%s,%s' % (
+        coordinates['y'], coordinates['x'])
 
     payload = {
-        'numSites':10,
+        'numSites': 10,
         'radius': circle,
     }
 
-
-    r = requests.get(url,params=payload,auth=(HMACAuth()))
-
+    r = requests.get(url, params=payload, auth=(HMACAuth()))
 
     temp = r.json()
     rjson = json.dumps(temp)
     rjson = json.loads(rjson)
     sites = []
-
 
     for site in rjson['sites']:
         sites.append(site['siteName'])
@@ -56,13 +55,13 @@ def findResturantsInRange(coordinates, radius):
 
 
 dict = {
-    'x' : '-84.3895',
-    'y' : '33.7891',
+    'x': '-84.3895',
+    'y': '33.7891',
 }
-rad=15
+rad = 15
 
 #geoCodeAddress('864 Spring St Nw, Atlanta, GA')
 
 #results =findResturantsInRange(dict,rad)
 
-#print(results)
+# print(results)


### PR DESCRIPTION
This updates the "benchmark" parameter to take in a string that _should_ always be the current set from the census API. https://geocoding.geo.census.gov/geocoder/benchmarks?page=1&size=10