### PR TITLE
Helm static serviceName fix

### DIFF
--- a/code/build/helm/charts/ncr-burgers-demo-static/templates/ingress/ncr-burgers-demo-static-ingress.yaml
+++ b/code/build/helm/charts/ncr-burgers-demo-static/templates/ingress/ncr-burgers-demo-static-ingress.yaml
@@ -20,6 +20,6 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ $.Release.Name }}-service
+              serviceName: {{ $.Release.Namespace }}
               servicePort: 8080
 {{- end}}


### PR DESCRIPTION
See: https://github.com/NCR-Corporation/ncr-retail-demo/blob/main/build/helm/charts/ncr-retail-demo-static/templates/ingress/ncr-retail-demo-static-ingress.yaml#L23