### PR TITLE
Adding Djangorestframework Back into Installations

### DIFF
--- a/code/build/cloudbuild/django/docker-startup.sh
+++ b/code/build/cloudbuild/django/docker-startup.sh
@@ -3,15 +3,9 @@ set -e
 
 sed -i \
     -e "s/^DEBUG\s*=.*$/DEBUG = False/" \
-    -e "s/^SECRET_KEY\s*=.*$/SECRET_KEY = ['${SECRET_KEY}']/" \
-    -e "s/^NEP_USERNAME\s*=.*$/NEP_USERNAME = '${NEP_USERNAME}'/" \
-    -e "s/^NEP_PASSWORD\s*=.*$/NEP_PASSWORD = '${NEP_PASSWORD}'/" \
-    -e "s/^NEP_APPLICATION_KEY\s*=.*$/NEP_APPLICATION_KEY = '${NEP_APPLICATION_KEY}'/" \
     -e "s/^NEP_ORGANIZATION\s*=.*$/NEP_ORGANIZATION = '${NEP_ORGANIZATION}'/" \
-    -e "s/^NEP_SHARED_KEY\s*=.*$/NEP_SHARED_KEY = '${NEP_SHARED_KEY}'/" \
     -e "s/^HMAC_SHARED_KEY\s*=.*$/HMAC_SHARED_KEY = '${HMAC_SHARED_KEY}'/" \
     -e "s/^HMAC_SECRET_KEY\s*=.*$/HMAC_SECRET_KEY = '${HMAC_SECRET_KEY}'/" \
-    -e "s/^CENSUS_API_KEY\s*=.*$/CENSUS_API_KEY = '${CENSUS_API_KEY}'/" \
     -e "s/^LOCATIONS\s*=.*$/LOCATIONS = {${LOCATIONS}}/" \
     BurgersUnlimited/settings.py
 

--- a/code/build/helm/charts/ncr-burgers-demo-app/templates/ncr-burgers-demo-app-deployment.yaml
+++ b/code/build/helm/charts/ncr-burgers-demo-app/templates/ncr-burgers-demo-app-deployment.yaml
@@ -36,22 +36,12 @@ spec:
               value: {{ quote .Values.Ingress.Burgers.Host }}
             - name: SECRET_KEY
               value: {{ quote .Values.Burgers.SecretKey }}
-            - name: NEP_USERNAME
-              value: {{ quote .Values.Burgers.NepUsername }}
-            - name: NEP_PASSWORD
-              value: {{ quote .Values.Burgers.NepPassword }}
-            - name: NEP_APPLICATION_KEY
-              value: {{ quote .Values.Burgers.NepApplicationKey }}
             - name: NEP_ORGANIZATION
               value: {{ quote .Values.Burgers.NepOrganization }}
-            - name: NEP_SHARED_KEY
-              value: {{ quote .Values.Burgers.NepSharedKey }}
             - name: HMAC_SHARED_KEY
               value: {{ quote .Values.Burgers.HmacSharedKey }}
             - name: HMAC_SECRET_KEY
               value: {{ quote .Values.Burgers.HmacSecretKey }}
-            - name: CENSUS_API_KEY
-              value: {{ quote .Values.Burgers.CensusApiKey }}
             - name: LOCATIONS
               value: {{ quote .Values.Burgers.Locations }}
           ports:

--- a/code/build/helm/charts/ncr-burgers-demo-app/values.yaml
+++ b/code/build/helm/charts/ncr-burgers-demo-app/values.yaml
@@ -1,38 +1,32 @@
 Master:
-  App:
-    Name: ncr-burgers-demo-app
-    Prefix: ncr-burgers-demo
-    ReleaseVersion:
-  ImagePullPolicy: Always
+    App:
+        Name: ncr-burgers-demo-app
+        Prefix: ncr-burgers-demo
+        ReleaseVersion:
+    ImagePullPolicy: Always
 Image:
-  Domain: us.gcr.io
-  Project:
-  PullPolicy: Always
+    Domain: us.gcr.io
+    Project:
+    PullPolicy: Always
 Scaling:
-  Burgers:
-    Enabled:
-    DefaultReplicas:
-    MinReplicas:
-    MaxReplicas:
-    TargetCpuUtilization:
-    TargetMemoryUtilization:
+    Burgers:
+        Enabled:
+        DefaultReplicas:
+        MinReplicas:
+        MaxReplicas:
+        TargetCpuUtilization:
+        TargetMemoryUtilization:
 Resources:
-  Burgers:
-    MinCpu:
-    MaxCpu:
-    MinMemory:
-    MaxMemory:
+    Burgers:
+        MinCpu:
+        MaxCpu:
+        MinMemory:
+        MaxMemory:
 Burgers:
-  SecretKey:
-  NepUsername:
-  NepPassword:
-  NepApplicationKey:
-  NepOrganization:
-  NepSharedKey:
-  HmacSharedKey:
-  HmacSecretKey:
-  CensusApiKey:
-  Locations:
+    NepOrganization:
+    HmacSharedKey:
+    HmacSecretKey:
+    Locations:
 Ingress:
-  Annotations: {}
-  Burgers: {}
+    Annotations: {}
+    Burgers: {}

--- a/code/docker-compose.yml
+++ b/code/docker-compose.yml
@@ -4,15 +4,9 @@ services:
   django:
     environment:
       URL_BASE: localhost
-      SECRET_KEY:
-      NEP_USERNAME:
-      NEP_PASSWORD:
-      NEP_APPLICATION_KEY:
       NEP_ORGANIZATION:
-      NEP_SHARED_KEY:
       HMAC_SHARED_KEY:
       HMAC_SECRET_KEY:
-      CENSUS_API_KEY:
       LOCATIONS:
     build:
       context: .

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -2,6 +2,7 @@ Django>=3.0,<4
 gunicorn==20.0.4
 requests>=2.25.1,<3
 django-crispy-forms>=1.13,<2
+djangorestframework>=3.12.1
 django-compressor>=2.4.1
 django-debug-toolbar>=3.2.2
 django-requests-debug-toolbar>=0.0.2


### PR DESCRIPTION
A possibly required install for the build that was taken out because it was thought to not be needed like Gunicorn.