### PR TITLE
changes for docker images working correctly. compose is still broken …

### DIFF
--- a/code/BurgersUnlimited/settings.py
+++ b/code/BurgersUnlimited/settings.py
@@ -25,7 +25,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'dist', 'static')
 SECRET_KEY = '$SECRET_KEY'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 mimetypes.add_type("application/javascript", ".js", True)
 
 ALLOWED_HOSTS = ['*']

--- a/code/BurgersUnlimited/settings.py
+++ b/code/BurgersUnlimited/settings.py
@@ -22,7 +22,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'dist', 'static')
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = ''
+SECRET_KEY = '$SECRET_KEY'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/code/Dockerfile
+++ b/code/Dockerfile
@@ -4,11 +4,13 @@ ENV PYTHONUNBUFFERED 1
 RUN mkdir -p /app
 WORKDIR /app
 COPY . /app
+RUN chmod +x /app
 
 RUN pip install -r requirements.txt && \
-    python manage.py collectstatic --noinput && \
-    chmod -R 777 /app
+    python manage.py collectstatic --noinput
 
+RUN cd ..
+RUN chmod -R 777 /app
 EXPOSE 8000/tcp
 
-ENTRYPOINT ["build/cloudbuild/django/docker-startup.sh"]
+CMD ["/bin/sh", "build/cloudbuild/django/docker-startup.sh"]

--- a/code/build/cloudbuild/django/docker-startup.sh
+++ b/code/build/cloudbuild/django/docker-startup.sh
@@ -7,7 +7,6 @@ sed -i \
     -e "s/^NEP_ORGANIZATION\s*=.*$/NEP_ORGANIZATION = '${NEP_ORGANIZATION}'/" \
     -e "s/^HMAC_SHARED_KEY\s*=.*$/HMAC_SHARED_KEY = '${HMAC_SHARED_KEY}'/" \
     -e "s/^HMAC_SECRET_KEY\s*=.*$/HMAC_SECRET_KEY = '${HMAC_SECRET_KEY}'/" \
-    -e "s/^LOCATIONS\s*=.*$/LOCATIONS = {${LOCATIONS}}/" \
     BurgersUnlimited/settings.py
 
 build/cloudbuild/django/gunicorn-start.sh

--- a/code/build/cloudbuild/django/gunicorn-start.sh
+++ b/code/build/cloudbuild/django/gunicorn-start.sh
@@ -10,7 +10,7 @@ echo "Starting $NAME as $(whoami)"
 
 # Activate the virtual environment
 cd $DJANGO_DIR || exit
-source $DJANGO_BUILD_DIR/activate.sh
+./build/cloudbuild/django/activate.sh
 export DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE
 export PYTHONPATH=$DJANGO_DIR:$PYTHONPATH
 

--- a/code/build/cloudbuild/nginx/Dockerfile
+++ b/code/build/cloudbuild/nginx/Dockerfile
@@ -1,7 +1,7 @@
 ARG NGINX_VERSION
 ARG NGINX_VARIANT
 
-FROM nginx:${NGINX_VERSION}-${NGINX_VARIANT}
+FROM nginx:1.15-alpine
 
 WORKDIR /etc/nginx/
 RUN rm /etc/nginx/nginx.conf /etc/nginx/conf.d/default.conf

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -6,3 +6,4 @@ django-compressor>=2.4.1
 django-debug-toolbar>=3.2.2
 django-requests-debug-toolbar>=0.0.2
 django-web-profiler>=0.1.4
+contextvars>=2.4


### PR DESCRIPTION
## Description
- made changes so docker images build successfully
- added a value to secret key to avoid error throw during image build
- changes to django dockerfile regarding permissions of files and call scripts with sh
- removed locations from django startup env vars
- hardcoded path for gunicorn script as it should never change
- hardcoded version of nginx, allows for the version to be used to be tracked
- added contextvars to settings file
- docker compose is still broken for me locally, but i got the two images to run and work locally in kubernetes
- turned off debug for django